### PR TITLE
Remove unnecessary variable, constant number moved to fields.

### DIFF
--- a/INPTP_AppForFixing/Entity/Employee.cs
+++ b/INPTP_AppForFixing/Entity/Employee.cs
@@ -10,18 +10,17 @@ namespace INPTP_AppForFixing
     {
         public int id;
         public string firstName, lastName, job;
-        public DateTime ourBirthDate;
+        public DateTime birthDate;
         public double monthlySalaryCZK;       
         public static double taxRate = 0.21;
+        private readonly int numberOfDays = 365;
 
         public int GetAge()
         {
-            int x = 0;
-            DateTime endDate = DateTime.Now;
-            TimeSpan timeSpan = endDate - ourBirthDate;
-            if (timeSpan.TotalDays > 365)
-                x = (int)Math.Round((timeSpan.TotalDays / 365), MidpointRounding.ToEven);
-            return x;
+            TimeSpan timeSpan = DateTime.Now - birthDate;
+            if (timeSpan.TotalDays > numberOfDays)
+                return (int)Math.Round((timeSpan.TotalDays / numberOfDays), MidpointRounding.ToEven);
+            return 0;
         }
 
         public virtual double CalcYearlySalaryCZK()
@@ -33,5 +32,6 @@ namespace INPTP_AppForFixing
         {
             return CalcYearlySalaryCZK() * (1 - taxRate);
         }
+
     }
 }

--- a/INPTP_AppForFixingTests/Entity/EmployeeClassTests.cs
+++ b/INPTP_AppForFixingTests/Entity/EmployeeClassTests.cs
@@ -16,7 +16,7 @@ namespace INPTP_AppForFixing.Tests
         {
             Employee emp = new Employee()
             {
-                ourBirthDate = DateTime.Now
+                birthDate = DateTime.Now
             };
 
             Assert.AreEqual(0, emp.GetAge());
@@ -29,7 +29,7 @@ namespace INPTP_AppForFixing.Tests
 
             Employee emp = new Employee()
             {
-                ourBirthDate = birthDate
+                birthDate = birthDate
             };
 
             Assert.AreEqual(1, emp.GetAge());
@@ -42,7 +42,7 @@ namespace INPTP_AppForFixing.Tests
 
             Employee emp = new Employee()
             {
-                ourBirthDate = birthDate
+                birthDate = birthDate
             };
 
             Assert.AreEqual(10, emp.GetAge());


### PR DESCRIPTION
Cleaning method getAge to clean code

- remove unnecessary variable
- rename variable ourBirthDate to birthDate / birth date is in class  Employee
- make a number of days reed only moved to fields

St46665